### PR TITLE
Corrected "Circle green" hash value

### DIFF
--- a/assets/targets/components/base/05-colour-palette-no-source.slim
+++ b/assets/targets/components/base/05-colour-palette-no-source.slim
@@ -52,7 +52,7 @@
     strong #0084EE
   div
     span class="circle green"
-    strong #3FC76E
+    strong #008a00
   div
     span class="circle cherry"
     strong #DF0620


### PR DESCRIPTION
Hash value printed on the page was wrong. Have updated to match the actual hash value.
